### PR TITLE
Add Asia (Tokyo) Region Support & Parallel Benchmark Optimization

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -9,8 +9,8 @@ on:
       max_parallel:
         description: 'Maximum number of parallel jobs (1-20, use 1 for sequential execution)'
         required: true
-        default: 10
-        type: number
+        default: '10'
+        type: string
 
 jobs:
   pre-warm:
@@ -26,7 +26,7 @@ jobs:
       matrix:
         region: [sea, iad, cdg, nrt]
         medium: [text, tools, image, audio]
-      max-parallel: ${{ github.event.inputs.max_parallel || 10 }}
+      max-parallel: ${{ fromJson(github.event.inputs.max_parallel || '10') }}
     
     steps:
       - name: Send Benchmark Request

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -20,7 +20,7 @@ jobs:
             ["tools"]=100
           )
           default_max_tokens=20
-          regions=("sea" "iad" "cdg")
+          regions=("sea" "iad" "cdg" "nrt")
           media=("text" "tools" "image" "audio")
           for region in "${regions[@]}"; do
             for medium in "${media[@]}"; do

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -23,6 +23,7 @@ jobs:
     needs: pre-warm
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         region: [sea, iad, cdg, nrt]
         medium: [text, tools, image, audio]
@@ -32,7 +33,12 @@ jobs:
       - name: Send Benchmark Request
         env:
           MAX_TOKENS: ${{ (matrix.medium == 'tools' && 100) || 20 }}
-        run: |
-          echo "Running benchmark for ${{ matrix.medium }} in region ${{ matrix.region }}"
-          curl -f -X POST "https://ai-benchmarks.fly.dev/bench?mode=${{ matrix.medium }}&max_tokens=$MAX_TOKENS&spread=30&store" -H "fly-prefer-region: ${{ matrix.region }}"
-          echo "Benchmark completed for ${{ matrix.medium }} in region ${{ matrix.region }}"
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_on: error
+          command: |
+            echo "Running benchmark for ${{ matrix.medium }} in region ${{ matrix.region }}"
+            curl -f -X POST "https://ai-benchmarks.fly.dev/bench?mode=${{ matrix.medium }}&max_tokens=${{ env.MAX_TOKENS }}&spread=30&store" -H "fly-prefer-region: ${{ matrix.region }}"
+            echo "Benchmark completed for ${{ matrix.medium }} in region ${{ matrix.region }}"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,24 +7,26 @@ on:
   workflow_dispatch:
 
 jobs:
-  run-benchmarks:
+  pre-warm:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Send Benchmark Requests
+      - name: Pre-warm audio instance
+        run: curl -f -X POST "https://ai-benchmarks.fly.dev/bench?mode=audio&max_tokens=20&num_requests=1"
+
+  run-benchmarks:
+    needs: pre-warm
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        region: [sea, iad, cdg, nrt]
+        medium: [text, tools, image, audio]
+      max-parallel: 20 # This is the limit of total concurrent jobs for the GitHub Free tier
+    
+    steps:
+      - name: Send Benchmark Request
+        env:
+          MAX_TOKENS: ${{ (matrix.medium == 'tools' && 100) || 20 }}
         run: |
-          # Pre-warm any spun-down instances (only audio right now)
-          curl -f -X POST "https://ai-benchmarks.fly.dev/bench?mode=audio&max_tokens=20&num_requests=1"
-          # Run the benchmarks
-          declare -A max_tokens=(
-            ["tools"]=100
-          )
-          default_max_tokens=20
-          regions=("sea" "iad" "cdg" "nrt")
-          media=("text" "tools" "image" "audio")
-          for region in "${regions[@]}"; do
-            for medium in "${media[@]}"; do
-              max_tokens=${max_tokens[$medium]:-$default_max_tokens}
-              curl -f -X POST "https://ai-benchmarks.fly.dev/bench?mode=$medium&max_tokens=$max_tokens&spread=30&store" -H "fly-prefer-region: $region"
-            done
-          done
+          echo "Running benchmark for ${{ matrix.medium }} in region ${{ matrix.region }}"
+          curl -f -X POST "https://ai-benchmarks.fly.dev/bench?mode=${{ matrix.medium }}&max_tokens=$MAX_TOKENS&spread=30&store" -H "fly-prefer-region: ${{ matrix.region }}"
+          echo "Benchmark completed for ${{ matrix.medium }} in region ${{ matrix.region }}"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -5,6 +5,12 @@ on:
     # Runs at 08:00 UTC every day
     - cron: "0 8 * * *"
   workflow_dispatch:
+    inputs:
+      max_parallel:
+        description: 'Maximum number of parallel jobs (1-20, use 1 for sequential execution)'
+        required: true
+        default: 10
+        type: number
 
 jobs:
   pre-warm:
@@ -20,7 +26,7 @@ jobs:
       matrix:
         region: [sea, iad, cdg, nrt]
         medium: [text, tools, image, audio]
-      max-parallel: 20 # This is the limit of total concurrent jobs for the GitHub Free tier
+      max-parallel: ${{ github.event.inputs.max_parallel || 10 }}
     
     steps:
       - name: Send Benchmark Request

--- a/utils/GenerateLatestData.js
+++ b/utils/GenerateLatestData.js
@@ -1,5 +1,5 @@
 // Define the regions to search for files
-const regions = ["cdg", "sea", "iad"];
+const regions = ["cdg", "sea", "iad", "nrt"];
 
 // Function to fetch data from a given URL
 async function fetchData(url) {

--- a/website/src/components/DataGrid.astro
+++ b/website/src/components/DataGrid.astro
@@ -71,6 +71,15 @@ import "ag-grid-community/styles/ag-theme-quartz.css";
           />
           <label for="cdgRegionSelector">Europe (Paris)</label>
         </div>
+        <div>
+          <input
+            type="radio"
+            id="nrtRegionSelector"
+            name="selectedRegion"
+            value="nrt"
+          />
+          <label for="cdgRegionSelector">Asia (Tokyo)</label>
+        </div>
       </div>
     </div>
     <div class="ml-8 flex flex-col">


### PR DESCRIPTION
# Tokyo Region Support & Parallel Benchmark Optimization

## Key Changes
- Introduced Asia (Tokyo) Region support
- Implemented parallel benchmark workflow using matrix strategy
- Optimized for multiple regions and media types
- Restructured workflow into pre-warm and run-benchmarks jobs

## Performance Enhancements
- Set max-parallel to 10 (optimized for GitHub Free tier's 20 concurrent job limit)
- Added retry mechanism for improved reliability

## Workflow Optimization
### BEFORE: Sequential execution **`10m 30s`**
 <img width="646" alt="Screenshot 2024-10-01 at 11 03 08 PM" src="https://github.com/user-attachments/assets/67e6f5df-1014-4629-867f-9e122c7be447">

### AFTER: 10 jobs running in parallel **`2m 25s`**
<img width="636" alt="Screenshot 2024-10-01 at 11 02 58 PM" src="https://github.com/user-attachments/assets/e7dc9e25-7ab6-44b7-9867-999737ce2c85">

## Additional Notes
- Deploy on Fly.io side for the `nrt` region is needed
- Introduced max parallel jobs flag in benchmark workflow for future flexibility